### PR TITLE
Fix a small todo

### DIFF
--- a/src/lattice.py
+++ b/src/lattice.py
@@ -393,14 +393,14 @@ class ConsciousnessLattice:
             for node in self.nodes:
                 node.attention /= total_attention
     
-    def update(self, delta_time: float, mouse_influence: Optional[Dict] = None):
+    def update(self, delta_time: float):
         """Update the entire consciousness lattice."""
         current_time = time.time()
         actual_delta_time = min(0.05, current_time - self.last_update_time)
         self.last_update_time = current_time
-        
+
         self.time += actual_delta_time * self.params['time_dilation']
-        
+
         # Process mouse influence from queue
         current_mouse_influence = self.mouse_influence_queue.pop(0) if self.mouse_influence_queue else None
 

--- a/src/lattice.py
+++ b/src/lattice.py
@@ -380,7 +380,11 @@ class ConsciousnessLattice:
             self.universes[universe_id].nodes.append(node)
     
     def _normalize_attention_field(self):
-        """Normalize attention field A(x) so ∫A(x)dμ(x) = 1."""
+        """
+        Normalize per-node attention so the lattice-wide attention distribution sums to 1.
+        
+        Calculates each node's attention via its calculate_attention_density() method and scales all attention values so their sum equals 1. If the total attention is zero, node attention values are left unchanged.
+        """
         total_attention = 0.0
         
         # Calculate attention for each node
@@ -394,7 +398,15 @@ class ConsciousnessLattice:
                 node.attention /= total_attention
     
     def update(self, delta_time: float):
-        """Update the entire consciousness lattice."""
+        """
+        Advance the lattice simulation by one update cycle, processing interactions, universes, clusters, and queued inputs.
+        
+        Parameters:
+            delta_time (float): Suggested time step in seconds for this update; the lattice may cap the applied step.
+        
+        Returns:
+            dict: Aggregate global consciousness metrics and state summary produced after the update.
+        """
         current_time = time.time()
         actual_delta_time = min(0.05, current_time - self.last_update_time)
         self.last_update_time = current_time


### PR DESCRIPTION
The mouse_influence parameter in ConsciousnessLattice.update() was never used since the implementation uses a queue-based approach (mouse_influence_queue) instead. This removes the dead code parameter to improve code clarity.

Changes:
- Removed unused mouse_influence parameter from update() method signature
- No functional changes - all callers only pass delta_time parameter
- Tests pass successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the public update API by removing an external mouse-influence input and consolidating state handling.
* **Documentation**
  * Clarified update behavior and return value (now documents time step and aggregate metrics).
  * Improved normalization notes to explain per-node scaling and behavior when total attention is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->